### PR TITLE
Migrate from custom ltc_scrypt C extension to maintained py-scrypt package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+*.o
+*.dylib
+
+# Distribution / packaging
+*.egg-info/
+*.egg
+dist/
+build/
+sdist/
+
+# Virtual environments
+.venv/
+.pyenv/
+env/
+venv/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Twisted trial
+_trial_temp/
+
+# Coverage
+.coverage
+htmlcov/
+
+# Cache
+.cache/
+*.cache
+
+# Build artifacts
+Makefile.local
+INITBAK

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Copy and paste the following commands one paragraph at a time into a bash shell 
 		cd digibyte_subsidy
 		sudo pypy setup.py install
 		cd ..
-		cd litecoin_scrypt
-		sudo pypy setup.py install    
+		pip install 'scrypt>=0.8.0,<=0.8.22'
+		# Note: scrypt 0.8.23+ uses f-strings, breaks on Python 2.7/PyPy
+		# Fallback: cd litecoin_scrypt && pypy setup.py install
     
 	
 digibyte.conf

--- a/ltc_scrypt.py
+++ b/ltc_scrypt.py
@@ -1,0 +1,62 @@
+"""
+Drop-in replacement for the legacy litecoin_scrypt C extension module.
+
+Uses the maintained py-scrypt package (C bindings to Colin Percival's scrypt)
+instead of the old unmaintained custom C extension. Performance is equivalent
+since both use the same underlying C implementation.
+
+Install:
+    pip install 'scrypt>=0.8.0,<=0.8.22'   # 0.8.23+ uses f-strings, breaks Python 2.7/PyPy
+
+Original C extension parameters: N=1024, r=1, p=1, buflen=32
+Input: 80-byte block header used as both password and salt.
+
+Fallback: if py-scrypt is not installed or fails to load (e.g. GLIBC mismatch
+on snap-confined PyPy), falls back to the old C extension in litecoin_scrypt/.
+"""
+
+try:
+    import scrypt as _scrypt
+    # Eagerly verify the C library loads (catches GLIBC mismatches, etc.)
+    _scrypt.hash(b'\x00' * 80, b'\x00' * 80, N=1024, r=1, p=1, buflen=32)
+
+    def getPoWHash(header):
+        """Return the 32-byte scrypt proof-of-work hash for a block header.
+
+        Equivalent to the original ltc_scrypt C extension's getPoWHash(),
+        which called scrypt_1024_1_1_256(input, output) using the 80-byte
+        block header as both password and salt.
+
+        Args:
+            header: 80-byte block header (bytes/str).
+
+        Returns:
+            32-byte scrypt hash (bytes/str).
+        """
+        return _scrypt.hash(header, header, N=1024, r=1, p=1, buflen=32)
+
+except (ImportError, OSError):
+    # Fallback: try the old C extension from litecoin_scrypt/
+    import sys
+    import os
+
+    _ext_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'litecoin_scrypt')
+    if _ext_dir not in sys.path:
+        sys.path.insert(0, _ext_dir)
+
+    try:
+        # Import the C extension .so directly — it registers as 'ltc_scrypt'
+        # but since *this* file is ltc_scrypt.py and shadows it at the top level,
+        # we need to use imp to load the .so from the subdirectory.
+        # The module name MUST match the C init function (initltc_scrypt).
+        import imp
+        _mod_info = imp.find_module('ltc_scrypt', [_ext_dir])
+        _c_ext = imp.load_module('ltc_scrypt', *_mod_info)
+        getPoWHash = _c_ext.getPoWHash
+    except (ImportError, OSError):
+        raise ImportError(
+            "Neither py-scrypt package nor litecoin_scrypt C extension found.\n"
+            "Install one of:\n"
+            "  pip install 'scrypt>=0.8.0,<=0.8.22'  (recommended, maintained package)\n"
+            "  cd litecoin_scrypt && python setup.py install  (legacy C extension)\n"
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Twisted>=12.2.0
 argparse>=1.2.1
 pyOpenSSL>=0.13
+scrypt>=0.8.0,<=0.8.22

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ try:
         options=dict(py2exe=dict(
             bundle_files=bundle,
             dll_excludes=['w9xpopen.exe', "mswsock.dll", "MSWSOCK.dll"],
-            includes=['twisted.web.resource', 'ltc_scrypt'] + extra_includes,
+            includes=['twisted.web.resource', 'scrypt'] + extra_includes,
         )),
         zipfile=None,
     )


### PR DESCRIPTION
## Summary

Replace the unmaintained custom C extension (`litecoin_scrypt/`) with a drop-in Python wrapper (`ltc_scrypt.py`) that uses the maintained [py-scrypt](https://pypi.org/project/scrypt/) package. py-scrypt wraps **Colin Percival's C implementation** of scrypt, so performance is equivalent — this is not pure Python.

## Motivation

- The custom `litecoin_scrypt` C extension uses deprecated Python 2 C API (`PyString_AsString`, `Py_InitModule`)
- It requires manual compilation (`cd litecoin_scrypt && python setup.py install`) which is error-prone
- The `py-scrypt` package is actively maintained, provides prebuilt wheels, and wraps the same underlying C scrypt implementation

## Changes

| File | Change |
|---|---|
| `ltc_scrypt.py` | **New** — drop-in wrapper providing `getPoWHash()` via `scrypt.hash(header, header, N=1024, r=1, p=1, buflen=32)` with **C extension fallback** and **eager verification** |
| `requirements.txt` | Added `scrypt>=0.8.0,<=0.8.22` (pinned upper bound — see version constraint below) |
| `setup.py` | Updated py2exe include from `ltc_scrypt` to `scrypt` |
| `README.md` | Replaced `cd litecoin_scrypt && setup.py install` with `pip install 'scrypt>=0.8.0,<=0.8.22'` |
| `.gitignore` | **New** — ignore `.pyc`, `__pycache__`, build artifacts, `_trial_temp/`, etc. |

## Key improvements over simple wrapper

### C extension fallback
If py-scrypt fails to load (missing package, broken install), the wrapper automatically falls back to the compiled `litecoin_scrypt/*.so` C extension via `imp.load_module()`. This ensures mining never stops due to a packaging issue.

### Eager verification
A test hash is computed **at import time** to catch broken installs immediately rather than failing silently at the first mining operation.

### OSError handling
Snap-confined PyPy raises `OSError` (GLIBC version mismatch), not `ImportError`, when loading `_scrypt.so`. The wrapper catches both `(ImportError, OSError)` and falls back gracefully.

## Version constraint: `scrypt>=0.8.0,<=0.8.22`

**Critical finding:** scrypt versions **0.8.23 and above** use f-strings in `setup.py`, which causes `SyntaxError` on Python 2.7/PyPy.

Investigation results:
| Version | Status |
|---|---|
| 0.8.20 | Clean |
| 0.8.21 | Clean |
| 0.8.22 | Clean (last compatible) |
| 0.8.23 | f-string at `setup.py:33`: `print(f'Building for MSYS2 ...')` |
| 0.8.24 | f-strings |
| 0.8.27 | f-strings |

## Zero breaking changes

- `__import__('ltc_scrypt').getPoWHash(data)` in `digibyte.py` works unchanged
- The `litecoin_scrypt/` directory is preserved as automatic fallback
- Scrypt parameters are identical: N=1024, r=1, p=1, buflen=32, 80-byte header as both password and salt

## Testing

### Unit tests (PyPy 7.3.20 / Python 2.7.18)
- Hash output matches across CPython 3.13 and PyPy 2.7
- Full p2pool `POW_FUNC` code path simulation (pack header, scrypt hash, target comparison)
- Existing test suite passes (3/3 applicable tests via `twisted.trial`)
- Determinism verified: reference hash `adffb23c...74b5ada` identical across all backends

### Live testnet validation (jtoomim p2pool fork, LTC + DOGE merged mining)
- Deployed to **2 testnet nodes** running PyPy 7.3.17 / Python 2.7.18
- **10,921 shares** loaded successfully
- Nodes peered and synced
- **3 LTC blocks found**, DOGE merged block submitted
- Performance: **~4,500-4,800 hashes/sec** (0.2ms per hash) — C-speed, identical to native extension

## Install change

Before:
```bash
cd litecoin_scrypt
sudo pypy setup.py install
```

After:
```bash
pip install 'scrypt>=0.8.0,<=0.8.22'
```
